### PR TITLE
Fixes response header format.

### DIFF
--- a/lib/rack/delegate/delegator.rb
+++ b/lib/rack/delegate/delegator.rb
@@ -40,6 +40,9 @@ module Rack
       def normalize_headers_for(http_response)
         http_response.to_hash.tap do |headers|
           headers.delete('status')
+          headers.each do |k,v|
+            headers[k] = v.join('; ')
+          end
         end
       end
     end


### PR DESCRIPTION
The proxied response headers for delegated requests are malformed.
This is caused by calling `to_hash` on the Net::HTTP response:

Example:

```
irb(main):053:0> uri = URI.parse("http://google.com/")
=> #<URI::HTTP http://google.com/>
irb(main):056:0> response = Net::HTTP.get_response(uri)
=> #<Net::HTTPFound 302 Found readbody=true>
irb(main):059:0> response.to_hash
=> {"cache-control"=>["private"], "content-type"=>["text/html; charset=UTF-8"], "location"=>["http://www.google.de/?gfe_rd=cr&ei=dY8xV9T-N8qo8weDj4cY"], "date"=>["Tue, 10 May 2016 07:36:21 GMT"], "content-length"=>["256"], "accept-ranges"=>["none"], "connection"=>["keep-alive"]}
```

Before:

```
< x-frame-options: ["SAMEORIGIN"]
< x-xss-protection: ["1; mode=block"]
< x-content-type-options: ["nosniff"]
< content-type: ["application/json; charset=utf-8"]
< cache-control: ["no-cache"]
< x-request-id: ["88ab1c21-4f44-4afc-940c-c9e2ee7fd352"]
< x-runtime: ["0.023663"]
< set-cookie: ["request_method=POST; path=/"]
```

After:

```
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< content-type: application/json; charset=utf-8
< cache-control: no-cache
< x-request-id: bbe645e9-7cd3-44d4-91c6-84a01b51b37d
< x-runtime: 0.031834
< set-cookie: request_method=POST; path=/
```
